### PR TITLE
Add listSubsriptionsByTopic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ code is still an ugly scala adaptation of the amazon samples
 ## SQS
 * List queues
 * Queue url by name
-* Create Queue
-* Delete Queue
-* send messages
-* receive messages
-* acknowledge messages
-* purge queues
-* get queue attributes
+* Create queue
+* Delete queue
+* Send messages
+* Receive messages
+* Acknowledge messages
+* Purge queues
+* gGet queue attributes
 
 ## SNS
 * Create topics
@@ -27,4 +27,5 @@ code is still an ugly scala adaptation of the amazon samples
 * Delete topic
 * Publish
 * Subscribe topic
-* List Subscriptions by Topic
+* List subscriptions by topic
+* Get/Set topic attributes

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ code is still an ugly scala adaptation of the amazon samples
 * Create topics
 * List topics (without paging, yet!)
 * Delete topic
+* Publish
+* Subscribe topic
+* List Subscriptions by Topic

--- a/sns/src/main/scala/com/github/bomgar/sns/AwsSnsClient.scala
+++ b/sns/src/main/scala/com/github/bomgar/sns/AwsSnsClient.scala
@@ -81,4 +81,15 @@ class AwsSnsClient(
       .map(SubscriptionReference.fromSubscribeResult)
   }
 
+  def listSubscriptionsByTopics(topic: TopicReference): Future[Seq[SubscriptionReference]] = {
+    val actionParameters = Map(
+      "Action" -> "ListSubscriptionsByTopic",
+      "TopicArn" -> topic.topicArn,
+      "Version" -> "2010-03-31"
+    )
+
+    executeFormEncodedAction(actionParameters)
+      .map(SubscriptionReference.fromListSubscriptionByTopicResult)
+  }
+
 }

--- a/sns/src/main/scala/com/github/bomgar/sns/AwsSnsClient.scala
+++ b/sns/src/main/scala/com/github/bomgar/sns/AwsSnsClient.scala
@@ -29,11 +29,11 @@ class AwsSnsClient(
       .map(TopicReference.fromCreateTopicResult)
   }
 
-  def getTopicAttributes(topicArn: String): Future[TopicAttributes] = {
+  def getTopicAttributes(topic: TopicReference): Future[TopicAttributes] = {
     val actionParameters = Map(
       "Action" -> "GetTopicAttributes",
       "Version" -> "2010-03-31",
-      "TopicArn" -> topicArn
+      "TopicArn" -> topic.topicArn
     )
 
     executeFormEncodedAction(actionParameters)

--- a/sns/src/main/scala/com/github/bomgar/sns/AwsSnsClient.scala
+++ b/sns/src/main/scala/com/github/bomgar/sns/AwsSnsClient.scala
@@ -40,6 +40,17 @@ class AwsSnsClient(
       .map(TopicAttributes.fromGetTopicAttributesResponse)
   }
 
+  def setTopicAttribute(topic: TopicReference, attributeName:String, attributeValue: String): Future[Unit] = {
+    val actionParameters = Map(
+      "TopicArn" -> topic.topicArn,
+      "Action" -> "SetTopicAttributes",
+      "AttributeName" -> attributeName,
+      "AttributeValue" -> attributeValue,
+      "Version" -> "2010-03-31"
+    )
+    executeFormEncodedAction(actionParameters).map(_ => ())
+  }
+
   def listTopics(): Future[Seq[TopicReference]] = {
     val actionParameters = Map(
       "Action" -> "ListTopics",

--- a/sns/src/main/scala/com/github/bomgar/sns/domain/SubscriptionReference.scala
+++ b/sns/src/main/scala/com/github/bomgar/sns/domain/SubscriptionReference.scala
@@ -8,16 +8,25 @@ object SubscriptionReference {
 
   def fromSubscribeResult(subscribeResult: Elem): SubscriptionReference = {
 
-    val subscriptionArnReturnValue = (subscribeResult \\ "SubscriptionArn").map(_.text).head
-    val confirmed = subscriptionArnReturnValue.startsWith("arn:aws:sns")
+    val subscriptionArn = (subscribeResult \\ "SubscriptionArn").map(_.text).head
 
-    val subscriptionArn = if (confirmed) {
-      Option(subscriptionArnReturnValue)
+    fromSubscriptionArn(subscriptionArn)
+  }
+
+  def fromListSubscriptionByTopicResult(listSubscriptionsResult: Elem): Seq[SubscriptionReference] = {
+    (listSubscriptionsResult \\ "SubscriptionArn").map(arnNode => fromSubscriptionArn(arnNode.text))
+  }
+
+  def fromSubscriptionArn(subscriptionArn: String): SubscriptionReference = {
+    val confirmed = subscriptionArn.startsWith("arn:aws:sns")
+
+    val arn = if (confirmed) {
+      Option(subscriptionArn)
     } else {
       None
     }
 
-    new SubscriptionReference(subscriptionArn, confirmed)
+    new SubscriptionReference(arn, confirmed)
   }
 
 }

--- a/sns/src/test/scala/com/github/bomgar/sns/SnsIntegrationTest.scala
+++ b/sns/src/test/scala/com/github/bomgar/sns/SnsIntegrationTest.scala
@@ -51,6 +51,19 @@ class SnsIntegrationTest extends Specification with FutureAwaits with DefaultAwa
     }
 
     tag("integration")
+    "set attribute for existing topic" in new WithTopic(wsClient) {
+      testTopic // create instance of lazy val
+      //amazon needs some time to include it in the list
+      Thread.sleep(2000)
+      val displayName: String = "dufte"
+
+      await(client.setTopicAttribute(testTopic, "DisplayName", displayName))
+
+      val topicAttributes = await(client.getTopicAttributes(testTopic))
+      topicAttributes.displayName must beSome (displayName)
+    }
+
+    tag("integration")
     "publish a message" in new WithTopic(wsClient) {
       testTopic // create instance of lazy val
       //amazon needs some time to include it in the list
@@ -69,7 +82,7 @@ class SnsIntegrationTest extends Specification with FutureAwaits with DefaultAwa
       subscriptionReference.confirmed must beTrue
       subscriptionReference.subscriptionArn must not beNone
 
-      Thread.sleep(10000) // 13 Jan 2016: Subscription assigned reliable not before 60sec
+      Thread.sleep(40000) // 13 Jan 2016: Subscription assigned reliable not before 60sec
       val topicAttributes = await(client.getTopicAttributes(testTopic))
 
       topicAttributes.subscriptionsConfirmed must beSome (1)

--- a/sns/src/test/scala/com/github/bomgar/sns/SnsIntegrationTest.scala
+++ b/sns/src/test/scala/com/github/bomgar/sns/SnsIntegrationTest.scala
@@ -49,7 +49,7 @@ class SnsIntegrationTest extends Specification with FutureAwaits with DefaultAwa
       //amazon needs some time to include it in the list
       Thread.sleep(2000)
 
-      val topicAttributes = await(client.getTopicAttributes(testTopic.topicArn))
+      val topicAttributes = await(client.getTopicAttributes(testTopic))
 
       topicAttributes.topicArn must beSome (testTopic.topicArn)
     }
@@ -79,8 +79,8 @@ class SnsIntegrationTest extends Specification with FutureAwaits with DefaultAwa
       subscriptionReference.confirmed must beTrue
       subscriptionReference.subscriptionArn must not beNone
 
-      Thread.sleep(25000) // Subscription assigned correctly not before 25sec (13 Jan 2016) - though immediately in mgmt console
-      val topicAttributes = await(client.getTopicAttributes(testTopic.topicArn))
+      Thread.sleep(60000) // Subscription assigned relliable not before 60sec (13 Jan 2016) - though immediately in mgmt console
+      val topicAttributes = await(client.getTopicAttributes(testTopic))
 
       topicAttributes.subscriptionsConfirmed must beSome (1)
     }

--- a/sns/src/test/scala/com/github/bomgar/sns/domain/SubscriptionReferenceTest.scala
+++ b/sns/src/test/scala/com/github/bomgar/sns/domain/SubscriptionReferenceTest.scala
@@ -1,0 +1,77 @@
+package com.github.bomgar.sns.domain
+
+import org.specs2.mutable.Specification
+
+class SubscriptionReferenceTest extends Specification {
+  "A SubsriptionReference" should {
+
+    "parse create topic result with a confirmed subscription" in {
+      val createSubscriptionResult =
+        <SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+          <SubscribeResult>
+            <SubscriptionArn>arn:aws:sns:us-west-2:123456789012:MyTopic:6b0e71bd-7e97-4d97-80ce-4a0994e55286</SubscriptionArn>
+          </SubscribeResult>
+          <ResponseMetadata>
+            <RequestId>c4407779-24a4-56fa-982c-3d927f93a775</RequestId>
+          </ResponseMetadata>
+        </SubscribeResponse>
+
+      val subscriptionReference = SubscriptionReference.fromSubscribeResult(createSubscriptionResult)
+
+      subscriptionReference.subscriptionArn must beSome ("arn:aws:sns:us-west-2:123456789012:MyTopic:6b0e71bd-7e97-4d97-80ce-4a0994e55286")
+      subscriptionReference.confirmed must beTrue
+    }
+
+    "parse create topic result with an unconfirmed subscription" in {
+      val createSubscriptionResult =
+        <SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+          <SubscribeResult>
+            <SubscriptionArn>pending confirmation</SubscriptionArn>
+          </SubscribeResult>
+          <ResponseMetadata>
+            <RequestId>c4407779-24a4-56fa-982c-3d927f93a775</RequestId>
+          </ResponseMetadata>
+        </SubscribeResponse>
+
+      val subscriptionReference = SubscriptionReference.fromSubscribeResult(createSubscriptionResult)
+
+      subscriptionReference.subscriptionArn must beNone
+      subscriptionReference.confirmed must beFalse
+    }
+
+    "parse parse a list of subscriptions" in {
+      val listSubscriptionsByTopic =
+        <ListSubscriptionsByTopicResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+          <ListSubscriptionsByTopicResult>
+            <Subscriptions>
+              <member>
+                <Owner>370621384784</Owner>
+                <Protocol>sqs</Protocol>
+                <Endpoint>arn:aws:sqs:eu-central-1:dufte:truppe</Endpoint>
+                <SubscriptionArn>arn:aws:sns:eu-central-1:dufte:truppe:2af7019d-1ac0-47e6-ffff-2382c49fcbdd</SubscriptionArn>
+                <TopicArn>arn:aws:sns:eu-central-1:dufte:truppe</TopicArn>
+              </member>
+              <member>
+                <Owner>370621384784</Owner>
+                <Protocol>email</Protocol>
+                <Endpoint>bla@bla.de</Endpoint>
+                <SubscriptionArn>PendingConfirmation</SubscriptionArn>
+                <TopicArn>arn:aws:sns:eu-central-1:dufte:truppe</TopicArn>
+              </member>
+            </Subscriptions>
+          </ListSubscriptionsByTopicResult>
+          <ResponseMetadata>
+            <RequestId>c4407779-24a4-56fa-982c-3d927f93a775</RequestId>
+          </ResponseMetadata>
+        </ListSubscriptionsByTopicResponse>
+
+      val subscriptionReferences = SubscriptionReference.fromListSubscriptionByTopicResult(listSubscriptionsByTopic)
+
+      subscriptionReferences.length must beEqualTo(2)
+      subscriptionReferences(0).subscriptionArn must beSome("arn:aws:sns:eu-central-1:dufte:truppe:2af7019d-1ac0-47e6-ffff-2382c49fcbdd")
+      subscriptionReferences(0).confirmed must beTrue
+      subscriptionReferences(1).subscriptionArn must beNone
+      subscriptionReferences(1).confirmed must beFalse
+    }
+  }
+}

--- a/sns/src/test/scala/com/github/bomgar/sns/testsupport/WithTopic.scala
+++ b/sns/src/test/scala/com/github/bomgar/sns/testsupport/WithTopic.scala
@@ -7,7 +7,6 @@ import org.specs2.mutable.After
 import org.specs2.specification.Scope
 import play.api.libs.ws.WSClient
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 
@@ -21,10 +20,10 @@ class WithTopic(wsClient: WSClient) extends Scope with FutureAwaits with Default
 
   lazy val client = new AwsSnsClient(new BasicAwsCredentialsProvider(awsCredentials), region, wsClient: WSClient)
 
-  lazy val topicName: String = generateTopicName()
+  lazy val topicName : String = generateRandomName()
   lazy val testTopic = await(client.createTopic(topicName))
 
-  private def generateTopicName(): String = Random.alphanumeric.take(10).mkString
+  def generateRandomName(): String = Random.alphanumeric.take(10).mkString
 
   override def after: Any = {
     // await(client.deleteTopic(testTopic))

--- a/sns/src/test/scala/com/github/bomgar/sns/testsupport/WithTopicAndTestQueue.scala
+++ b/sns/src/test/scala/com/github/bomgar/sns/testsupport/WithTopicAndTestQueue.scala
@@ -1,0 +1,16 @@
+package com.github.bomgar.sns.testsupport
+
+import com.github.bomgar.auth.credentials.BasicAwsCredentialsProvider
+import com.github.bomgar.sqs.AwsSqsClient
+import play.api.libs.ws.WSClient
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class WithTopicAndTestQueue (wsClient: WSClient) extends WithTopic (wsClient) {
+
+  lazy val sqsClient = new AwsSqsClient(new BasicAwsCredentialsProvider(awsCredentials),region, wsClient)
+  lazy val queueName : String = generateRandomName()
+  lazy val testQueue = await(sqsClient.createQueue(queueName))
+  lazy val testQueueAttributes = await(sqsClient.getQueueAttributes(testQueue,Seq("QueueArn")))
+  lazy val testQueueArn: String = testQueueAttributes.queueArn.getOrElse(throw new RuntimeException("Failed to get arn from testqueue"))
+
+}


### PR DESCRIPTION
Ich bekomme von Idea immer die Warnung:

`Warning:(x,y) Field defined in DelayedInit is likely to be null`

Dass bezieht sich auf die vals die in `testsupport/WithTopic` definiert sind. Witzigerweise betrifft es keine Felder in `WithTopicAndTestQueue`.

Hast Du das auch? Hast du eine Idee, woher das kommt?
Hab eine bisschen dazu gegoogelt, aber nichts sinnvolles gefunden. [Das hier](http://stackoverflow.com/questions/13009265/what-happens-in-scala-when-loading-objects-that-extends-app) erklärt zwar den Zusammehang zu DelayedInit - aber nicht warum das bei unseren Feldern auftaucht..
